### PR TITLE
chore: added GCP workload identity example

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -43,6 +43,15 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      ## GCP Workload Identity - Keyless authentication
+      # - id: 'auth'
+      #   name: Auth
+      #   uses: google-github-actions/auth@v1
+      #   with:
+      #     token_format: 'access_token'
+      #     workload_identity_provider: 'projects/<gcp_project_number>/locations/global/workloadIdentityPools/<workloadIdentity_id>/providers/<workloadIdentity_provider_id>'
+      #     service_account: '<gcp_service_account>@<gcp_project_id>.iam.gserviceaccount.com'
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -78,6 +87,14 @@ jobs:
       #     registry: gcr.io
       #     username: _json_key
       #     password: ${{ secrets.GCR_JSON_KEY }}
+
+      ## GCP Workload Identity
+      # - name: Login to GCR using Workload Identity OAuth token
+      #   uses: 'docker/login-action@v1'
+      #   with:
+      #     registry: 'us.gcr.io'
+      #     username: 'oauth2accesstoken'
+      #     password: '${{ steps.auth.outputs.access_token }}'
 
       - name: Build and deploy to Dagster Cloud hybrid
         uses: dagster-io/dagster-cloud-action/actions/hybrid_branch_deploy@v0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,15 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      ## GCP Workload Identity - Keyless authentication
+      # - id: 'auth'
+      #   name: Auth
+      #   uses: google-github-actions/auth@v1
+      #   with:
+      #     token_format: 'access_token'
+      #     workload_identity_provider: 'projects/<gcp_project_number>/locations/global/workloadIdentityPools/<workloadIdentity_id>/providers/<workloadIdentity_provider_id>'
+      #     service_account: '<gcp_service_account>@<gcp_project_id>.iam.gserviceaccount.com'
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -73,6 +82,14 @@ jobs:
       #     registry: gcr.io
       #     username: _json_key
       #     password: ${{ secrets.GCR_JSON_KEY }}
+
+      ## GCP Workload Identity
+      # - name: Login to GCR using Workload Identity OAuth token
+      #   uses: 'docker/login-action@v1'
+      #   with:
+      #     registry: 'us.gcr.io'
+      #     username: 'oauth2accesstoken'
+      #     password: '${{ steps.auth.outputs.access_token }}'
 
       - name: Build and deploy to Dagster Cloud hybrid
         uses: dagster-io/dagster-cloud-action/actions/hybrid_prod_deploy@v0.1


### PR DESCRIPTION
Added an example using Google Cloud authentication with Workload Identity Federation.
This is useful since it's a keyless integration between GitHub actions and Google Cloud.