### PR TITLE
Update hybrid quickstart to use ubuntu 22.04

### DIFF
--- a/.github/workflows/dagster-cloud-deploy.yml
+++ b/.github/workflows/dagster-cloud-deploy.yml
@@ -25,7 +25,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   dagster-cloud-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # If this is a closed PR the prerun step closes the branch deployment and returns
       # output.result='skip' which is used to skip other steps in this workflow.


### PR DESCRIPTION
Summary:
20.04 uses python 3.8 by default which is at EOL.

Test Plan: Use this yaml to deploy a new hybrid org
