### PR TITLE
further specify concurrency group

### DIFF
--- a/.github/workflows/dagster-cloud-deploy.yml
+++ b/.github/workflows/dagster-cloud-deploy.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   # Cancel in-progress deploys to the same branch
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 env:
   # The organization name in Dagster Cloud


### PR DESCRIPTION
When using the hybrid quickstart gh action, I ended up running into an issue where when merging a PR after a branch deployment successfully ran, the branch close flow would run in the same group as the main flow, since the ref is the same, and one of the runs would be canceled. The result was that the branch deployment closed and nothing else.

This fixes by also indexing on the name of the event, which i think gets closer to the intended affect.

I can verify that this also fixed on my run of the action. See original: https://github.com/dagster-io/base-dagster-repo/actions/runs/12040973366
and after: https://github.com/dagster-io/base-dagster-repo/actions/runs/12041102759